### PR TITLE
fix(chatgpt): ボタンが増殖する不具合を止めた（Issue #9）

### DIFF
--- a/ai_clients/chatgpt/client.js
+++ b/ai_clients/chatgpt/client.js
@@ -324,7 +324,6 @@
       saveButton.className = BUTTON_CLASS;
       saveButton.textContent = 'Notionへ保存';
       saveButton.title = 'Notionへ保存';
-      saveButton.style.marginLeft = '8px';
       saveButton.addEventListener('click', (event) => {
         if (!flows || !flows.handleSaveResponse) {
           log.warn('[Archiver] ChatGPT save failed: reason=flow_unavailable');

--- a/ai_clients/chatgpt/client.js
+++ b/ai_clients/chatgpt/client.js
@@ -272,6 +272,10 @@
       const btnContainer = document.createElement('div');
       btnContainer.className = BUTTON_CONTAINER_CLASS;
       btnContainer.setAttribute(UI_ATTR, '1');
+      // Match ChatGPT message width to avoid drifting outside the prose area.
+      btnContainer.style.maxWidth = '640px';
+      btnContainer.style.marginLeft = 'auto';
+      btnContainer.style.marginRight = 'auto';
 
       const importButton = document.createElement('button');
       importButton.className = BUTTON_CLASS;

--- a/ai_clients/chatgpt/client.js
+++ b/ai_clients/chatgpt/client.js
@@ -266,9 +266,8 @@
     if (!assistantBlocks.length) return;
 
     assistantBlocks.forEach((block) => {
-      if (block.getAttribute(INJECTED_ATTR) === '1') return;
+      if (isAlreadyInjected(block)) return;
       if (!block.textContent || block.textContent.trim().length < 10) return;
-      if (block.querySelector(`[${UI_ATTR}="1"]`)) return;
 
       const btnContainer = document.createElement('div');
       btnContainer.className = BUTTON_CONTAINER_CLASS;
@@ -362,7 +361,7 @@
     const primary = Array.from(
       document.querySelectorAll('[data-message-author-role="assistant"]'),
     );
-    if (primary.length > 0) return primary;
+    if (primary.length > 0) return normalizeMessageBlocks(primary);
 
     const main = document.querySelector('main') || document.querySelector('[role="main"]');
     if (!main) return [];
@@ -371,7 +370,8 @@
       main.querySelectorAll('article, section, div'),
     );
 
-    return candidates.filter((el) => isLikelyMessage(el));
+    const likelyMessages = candidates.filter((el) => isLikelyMessage(el));
+    return normalizeMessageBlocks(likelyMessages);
   }
 
   function collectMessageElements(main) {
@@ -470,6 +470,33 @@
 
     if (parts.length === 0) return '';
     return parts.join(' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function isAlreadyInjected(block) {
+    if (!block || block.nodeType !== 1) return true;
+    if (block.getAttribute(INJECTED_ATTR) === '1') return true;
+    if (block.querySelector(`[${UI_ATTR}="1"]`)) return true;
+
+    const injectedAncestor = block.closest(`[${INJECTED_ATTR}="1"]`);
+    if (injectedAncestor && injectedAncestor !== block) return true;
+
+    if (block.closest(`[${UI_ATTR}="1"]`)) return true;
+    return false;
+  }
+
+  function normalizeMessageBlocks(blocks) {
+    const uniqueBlocks = [];
+    const seen = new Set();
+
+    blocks.forEach((block) => {
+      if (!block || seen.has(block)) return;
+      seen.add(block);
+      uniqueBlocks.push(block);
+    });
+
+    return uniqueBlocks.filter((block) => {
+      return !uniqueBlocks.some((other) => other !== block && other.contains(block));
+    });
   }
 
   function isLikelyMessage(el) {


### PR DESCRIPTION
## 概要
Issue #9 の対応。ChatGPTページでボタンが何回も出てしまう不具合を直し、ボタンの間隔も揃えた。

## やったこと
- ✅ ボタンが複数回表示されるバグを修正
  - `isAlreadyInjected(block)`: そのメッセージにすでにボタンを付けたかをチェックして、付け済みならもう一度付けない。
  - `normalizeMessageBlocks(blocks)`: 似た要素が「親子で重複して取れた」とき、いちばん外側だけ残して内側は捨てる（ボタンが二重に付くのを防ぐ）。
- ✅ 「Notionへ保存」だけ左にズレてたのを直して、3つのボタンの間隔を同じにした

## 備考
- ボタンを 👍👎 の列の「右下」に置く　は後回しにした #14 
  - **理由**: 何度か試したがうまくいかず、DOMの把握と置き場所の特定に時間がかかるから